### PR TITLE
The sizes attribute requires the srcset attribute.

### DIFF
--- a/src/templates/img.twig
+++ b/src/templates/img.twig
@@ -18,7 +18,9 @@
       {% set classOutput = true %}
       {{ key }}="{{ value }} lazyload"
     {% else %}
-      {{ key }}="{{ value }}"
+       {% if key != 'sizes' or attrs.srcset is defined %}
+         {{key}}="{{value}}"
+       {% endif %}
     {% endif %}
   {% endfor %}
   {% if not classOutput %}
@@ -28,4 +30,3 @@
     src="{{ lazysizes }}"
   {% endif %}
 />
-


### PR DESCRIPTION
The HTML5 validator flagged this when I checked the Bywater about page.